### PR TITLE
Replace MQTT with HA REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ ESPHome project using an e-paper display to show information meant for quick gla
 - [Adafruit 2500mah LiPo Battery](https://www.adafruit.com/product/328)
 
 ## Details
-This is a Home Assistant focused display that grabs sensor details from MQTT to optimize speed. An example of the Home Assistant config that this uses can be found [here](https://gist.github.com/owenb321/3a1caad7bbbfdebaf21a7f56c705fa58#file-epaper_sensors-yaml).
+This is a Home Assistant focused display that fetches sensor data via the Home Assistant REST API on each wake cycle.
 
-MQTT is used to expedite the update interval since the Home Assistant API takes up to a minute to provide new information. MQTT with persist flags allows ESPHome to pull the information immeditately upon waking up without connecting to the HA API first.
+On boot, the device makes a single `POST` to the HA `/api/template` endpoint with a Jinja2 template that returns all required sensor values as JSON in one request. This avoids the latency of the native HA API (which requires HA to discover and connect to the device) while still pulling current data directly from HA.
 
 The Waveshare display consumes power during the ESP32 deep sleep so the TPL5111 timer is used to cut power between update intervals to maximize battery life. Battery life with a 2500mah LiPo has been about 3 months in real world usage.
+
+## Configuration
+Copy `secrets.yaml.example` to `secrets.yaml` and fill in your values:
+- `wifi_ssid` / `wifi_password` — wireless network credentials
+- `ha_base_url` — Home Assistant base URL (e.g. `http://192.168.1.1:8123`)
+- `ha_token` — Home Assistant long-lived access token (`Bearer eyJ...`), generated under Profile → Security → Long-Lived Access Tokens
 
 The case is laser cut and can be screwed shut or just held together with the slot/tab design. SVG files for cutting are found in the [case directory](case)

--- a/generate_icon.py
+++ b/generate_icon.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Download an MDI icon from pictogrammers.com and convert it to the 1bpp BMP
+format used by the e-ink display project.
+
+Usage:
+  python3 generate_icon.py <icon-name> [--type <notification|weather|other>] [--sizes <128,64,36>]
+
+Examples:
+  # Generate all three notification sizes for battery-charging:
+  python3 generate_icon.py battery-charging --type notification
+
+  # Generate a single custom size:
+  python3 generate_icon.py thermometer --sizes 36 --out icon-bmp/weather-small/thermometer2.bmp
+
+The SVG is fetched from the MDI GitHub repository:
+  https://raw.githubusercontent.com/Templarian/MaterialDesign/master/svg/<name>.svg
+
+Output BMP format:
+  - 1bpp palette BMP
+  - Palette index 0 = black (background/transparent)
+  - Palette index 1 = white (drawn icon pixel)
+  This matches the 'invert_alpha: true' convention used in waveshare.yaml.
+"""
+
+import argparse
+import io
+import os
+import struct
+import sys
+import urllib.request
+
+
+try:
+    import cairosvg
+except ImportError:
+    sys.exit("cairosvg is required: pip install cairosvg")
+
+try:
+    from PIL import Image
+except ImportError:
+    sys.exit("Pillow is required: pip install Pillow")
+
+
+MDI_SVG_URL = "https://raw.githubusercontent.com/Templarian/MaterialDesign/master/svg/{name}.svg"
+
+# Notification icon sizes matched to the three subdirectories
+NOTIFICATION_SIZES = {
+    "notification-large": 128,
+    "notification-med": 64,
+    "notification-small": 36,
+}
+
+
+def fetch_svg(icon_name: str) -> bytes:
+    url = MDI_SVG_URL.format(name=icon_name)
+    print(f"Fetching: {url}")
+    try:
+        with urllib.request.urlopen(url) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        sys.exit(f"Failed to download icon '{icon_name}': HTTP {e.code}\n"
+                 f"Check the name at https://pictogrammers.com/library/mdi/")
+
+
+def svg_to_1bpp_bmp(svg_bytes: bytes, size: int) -> Image.Image:
+    """Render SVG to an RGBA PNG then convert to 1bpp BMP.
+
+    Convention: alpha > 0 (visible icon pixel) → palette index 1 (white)
+                alpha == 0 (background)         → palette index 0 (black)
+    This matches 'invert_alpha: true' in ESPHome.
+    """
+    png_bytes = cairosvg.svg2png(
+        bytestring=svg_bytes,
+        output_width=size,
+        output_height=size,
+    )
+    rgba = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+
+    # Build a 1bpp palette image manually:
+    # index 0 = black (BG), index 1 = white (icon)
+    bmp = Image.new("P", (size, size), 0)
+    palette = [0, 0, 0] + [255, 255, 255] + [0] * (256 * 3 - 6)
+    bmp.putpalette(palette)
+
+    pixels = bmp.load()
+    rgba_pixels = rgba.load()
+    for y in range(size):
+        for x in range(size):
+            r, g, b, a = rgba_pixels[x, y]
+            # Any visible pixel (non-transparent) becomes index 1
+            pixels[x, y] = 1 if a > 128 else 0
+
+    return bmp
+
+
+def save_1bpp_bmp(img: Image.Image, path: str):
+    """Write a true 1bpp BMP matching the project's existing icon format.
+
+    Palette convention (matches existing icons):
+      Color index 0 = white (0xFF 0xFF 0xFF) = background / transparent
+      Color index 1 = black (0x00 0x00 0x00) = drawn icon pixel
+    Pixel data: bit 1 = icon pixel, bit 0 = background (MSB first per byte).
+    Rows are stored bottom-to-top (positive height in header).
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+
+    w, h = img.size
+    # Row stride: bits per row rounded up to a multiple of 32 bits (4 bytes)
+    row_stride = ((w + 31) // 32) * 4
+
+    # Build pixel data (bottom-to-top row order)
+    pixel_data = bytearray(row_stride * h)
+    pix = img.load()
+    for y in range(h):
+        bmp_row = h - 1 - y  # BMP rows are stored bottom-to-top
+        for x in range(w):
+            if pix[x, y] == 1:  # icon pixel
+                byte_idx = bmp_row * row_stride + x // 8
+                bit_shift = 7 - (x % 8)
+                pixel_data[byte_idx] |= (1 << bit_shift)
+
+    # BMP file header (14 bytes) + BITMAPINFOHEADER (40 bytes)
+    # + 2-color palette (2 × 4 bytes) + pixel data
+    pixel_data_offset = 14 + 40 + 2 * 4
+    file_size = pixel_data_offset + len(pixel_data)
+
+    file_header = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, pixel_data_offset)
+    dib_header = struct.pack(
+        "<IiiHHIIiiII",
+        40,           # DIB header size
+        w, h,         # width, height (positive = bottom-to-top)
+        1,            # color planes
+        1,            # bits per pixel
+        0,            # compression (none)
+        len(pixel_data),  # image size
+        2835, 2835,   # pixels per meter X/Y (~72 DPI)
+        2,            # colors in table
+        0,            # important colors (0 = all)
+    )
+    # Palette: color 0 = white (background), color 1 = black (icon pixel)
+    palette = (
+        struct.pack("<BBBB", 255, 255, 255, 0) +  # index 0: white
+        struct.pack("<BBBB", 0, 0, 0, 0)           # index 1: black
+    )
+
+    with open(path, "wb") as f:
+        f.write(file_header)
+        f.write(dib_header)
+        f.write(palette)
+        f.write(pixel_data)
+
+    print(f"  Saved: {path}  ({os.path.getsize(path)} bytes, 1bpp)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate 1bpp BMP icons from MDI SVGs")
+    parser.add_argument("icon_name", help="MDI icon name, e.g. battery-charging")
+    parser.add_argument(
+        "--type",
+        choices=["notification", "weather", "other"],
+        default="notification",
+        help="Icon type: 'notification' generates all three sizes into the notification-* dirs (default)",
+    )
+    parser.add_argument(
+        "--sizes",
+        help="Comma-separated pixel sizes, e.g. 128,64,36 (overrides --type sizes)",
+    )
+    parser.add_argument(
+        "--out",
+        help="Output file path (only valid with a single --sizes value)",
+    )
+    parser.add_argument(
+        "--base-dir",
+        default=os.path.dirname(os.path.abspath(__file__)),
+        help="Base directory of the project (default: directory of this script)",
+    )
+    args = parser.parse_args()
+
+    svg_bytes = fetch_svg(args.icon_name)
+
+    if args.sizes:
+        sizes = [int(s.strip()) for s in args.sizes.split(",")]
+        if args.out:
+            if len(sizes) != 1:
+                sys.exit("--out requires exactly one size in --sizes")
+            img = svg_to_1bpp_bmp(svg_bytes, sizes[0])
+            save_1bpp_bmp(img, args.out)
+        else:
+            for sz in sizes:
+                img = svg_to_1bpp_bmp(svg_bytes, sz)
+                out = os.path.join(args.base_dir, "icon-bmp", f"{args.icon_name}-{sz}.bmp")
+                save_1bpp_bmp(img, out)
+    elif args.type == "notification":
+        for subdir, size in NOTIFICATION_SIZES.items():
+            img = svg_to_1bpp_bmp(svg_bytes, size)
+            out = os.path.join(
+                args.base_dir, "icon-bmp", subdir, f"{args.icon_name}.bmp"
+            )
+            save_1bpp_bmp(img, out)
+    else:
+        parser.error("Specify --sizes or use --type notification")
+
+
+if __name__ == "__main__":
+    main()

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -1,0 +1,4 @@
+wifi_ssid: "your_wifi_ssid"
+wifi_password: "your_wifi_password"
+ha_base_url: "http://192.168.1.1:8123"
+ha_token: "Bearer eyJ..."

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -137,7 +137,8 @@ http_request:
   timeout: 10s
 
 ota:
-  safe_mode: false
+  - platform: esphome
+    safe_mode: false
 
 switch:
   - platform: gpio

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -9,17 +9,87 @@ esphome:
     priority: -100
     then:
       - component.update: sntp_time
-      - wait_until:
-          condition:
-            mqtt.connected:
-          timeout: 60s
-      # Turn off if mqtt connection isn't established
-      - if:
-          condition:
-            not:
-              mqtt.connected:
-          then:
-            - switch.turn_on: tpl5111_done
+      - http_request.post:
+          url: http://192.168.1.1:8123/api/template
+          capture_response: true
+          request_headers:
+            Authorization: !secret ha_token
+            Content-Type: application/json
+          json:
+            template: >-
+              {{ {
+                'temp': states('sensor.openweathermap_temperature') | float(0),
+                'humidity': states('sensor.openweathermap_humidity') | float(0),
+                'forecast_high': states('sensor.forecast_high') | float(0),
+                'forecast_low': states('sensor.forecast_low') | float(0),
+                'wind_bearing': states('sensor.openweathermap_wind_bearing') | float(0),
+                'wind_speed': states('sensor.openweathermap_wind_speed') | float(0),
+                'rain_daily': states('sensor.rain_daily') | float(0),
+                'weather_condition': states('sensor.current_weather_condition_num') | float(-1),
+                'upstairs_temp': states('sensor.upstairs_average_temperature') | float(0),
+                'downstairs_temp': states('sensor.downstairs_average_temperature') | float(0),
+                'basement_temp': states('sensor.basement_temperature_sensor') | float(0),
+                'upstairs_humidity': states('sensor.bedroom_humidity_sensor') | float(0),
+                'downstairs_humidity': states('sensor.family_room_humidity_sensor') | float(0),
+                'basement_humidity': states('sensor.basement_humidity_sensor') | float(0),
+                'ota_mode': is_state('input_boolean.waveshare_ota_mode', 'on'),
+                'sleep_mode': is_state('input_boolean.waveshare_sleep_mode', 'on'),
+                'show_qr_code': is_state('input_boolean.waveshare_show_qr_code', 'on'),
+                'show_indoor_temp': is_state('input_boolean.waveshare_show_indoor_temp', 'on'),
+                'event_1_date': states('sensor.upcoming_event_1_date'),
+                'event_1_name': states('sensor.upcoming_event_1_name'),
+                'event_1_icon': states('sensor.upcoming_event_1_icon'),
+                'event_2_date': states('sensor.upcoming_event_2_date'),
+                'event_2_name': states('sensor.upcoming_event_2_name'),
+                'event_2_icon': states('sensor.upcoming_event_2_icon'),
+                'event_3_date': states('sensor.upcoming_event_3_date'),
+                'event_3_name': states('sensor.upcoming_event_3_name'),
+                'event_3_icon': states('sensor.upcoming_event_3_icon'),
+                'forecast_conditions': states('sensor.forecast_condition_nums'),
+                'notification_string': states('sensor.epaper_notifications')
+              } | tojson }}
+          on_response:
+            then:
+              - lambda: |-
+                  if (response->status_code != 200) {
+                    id(tpl5111_done).turn_on();
+                    return;
+                  }
+                  json::parse_json(body, [](JsonObject root) -> bool {
+                    id(outdoor_temperature).publish_state(root["temp"].as<float>());
+                    id(outdoor_humidity).publish_state(root["humidity"].as<float>());
+                    id(forecast_high).publish_state(root["forecast_high"].as<float>());
+                    id(forecast_low).publish_state(root["forecast_low"].as<float>());
+                    id(wind_bearing).publish_state(root["wind_bearing"].as<float>());
+                    id(wind_speed).publish_state(root["wind_speed"].as<float>());
+                    id(rain_daily).publish_state(root["rain_daily"].as<float>());
+                    id(weather_condition).publish_state(root["weather_condition"].as<float>());
+                    id(upstairs_temperature).publish_state(root["upstairs_temp"].as<float>());
+                    id(downstairs_temperature).publish_state(root["downstairs_temp"].as<float>());
+                    id(basement_temperature).publish_state(root["basement_temp"].as<float>());
+                    id(upstairs_humidity).publish_state(root["upstairs_humidity"].as<float>());
+                    id(downstairs_humidity).publish_state(root["downstairs_humidity"].as<float>());
+                    id(basement_humidity).publish_state(root["basement_humidity"].as<float>());
+                    id(ota_mode).publish_state(root["ota_mode"].as<bool>());
+                    id(sleep_mode).publish_state(root["sleep_mode"].as<bool>());
+                    id(show_qr_code).publish_state(root["show_qr_code"].as<bool>());
+                    id(show_indoor_temp).publish_state(root["show_indoor_temp"].as<bool>());
+                    id(event_1_date).publish_state(root["event_1_date"].as<std::string>());
+                    id(event_1_name).publish_state(root["event_1_name"].as<std::string>());
+                    id(event_1_icon).publish_state(root["event_1_icon"].as<std::string>());
+                    id(event_2_date).publish_state(root["event_2_date"].as<std::string>());
+                    id(event_2_name).publish_state(root["event_2_name"].as<std::string>());
+                    id(event_2_icon).publish_state(root["event_2_icon"].as<std::string>());
+                    id(event_3_date).publish_state(root["event_3_date"].as<std::string>());
+                    id(event_3_name).publish_state(root["event_3_name"].as<std::string>());
+                    id(event_3_icon).publish_state(root["event_3_icon"].as<std::string>());
+                    id(forecast_conditions).publish_state(root["forecast_conditions"].as<std::string>());
+                    id(notification_string).publish_state(root["notification_string"].as<std::string>());
+                    return true;
+                  });
+          on_error:
+            then:
+              - switch.turn_on: tpl5111_done
       # Wait for some valid temp data
       - wait_until:
           sensor.in_range:
@@ -27,6 +97,15 @@ esphome:
             above: -460
       - delay: 1s
       - component.update: battery_voltage
+      - lambda: |-
+          // Add battery-low notification locally if voltage is below threshold
+          if (id(battery_voltage).state < 3.35) {
+            bool already_present = false;
+            for (int n : id(notification_nums)) {
+              if (n == 8) { already_present = true; break; }
+            }
+            if (!already_present) id(notification_nums).push_back(8);
+          }
       - wait_until:
           time.has_time:
       - component.update: epaper_display
@@ -48,13 +127,9 @@ wifi:
 logger:
   level: DEBUG
 
-# Using MQTT instead of the Home Assistant API
-#   since it grabs the data after waking much faster
-mqtt:
-  broker: 192.168.1.1
-  discovery: false
-  topic_prefix: waveshare_display
-  
+http_request:
+  timeout: 10s
+
 ota:
   safe_mode: false
 
@@ -112,168 +187,118 @@ sensor:
     id: battery_voltage
     filters:
       - multiply: 2
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Outdoor Temperature"
     id: outdoor_temperature
     internal: true
-    topic: waveshare_display/input/sensor/openweathermap_temperature
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Outdoor Humidity"
     id: outdoor_humidity
     internal: true
-    topic: waveshare_display/input/sensor/openweathermap_humidity
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Forecast High"
     id: forecast_high
     internal: true
-    topic: waveshare_display/input/sensor/forecast_high
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Forecast Low"
     id: forecast_low
     internal: true
-    topic: waveshare_display/input/sensor/forecast_low
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Wind Bearing"
     id: wind_bearing
     internal: true
-    topic: waveshare_display/input/sensor/openweathermap_wind_bearing
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Wind Speed"
     id: wind_speed
     internal: true
-    topic: waveshare_display/input/sensor/openweathermap_wind_speed
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Rain Meter Daily"
     id: rain_daily
     internal: true
-    topic: waveshare_display/input/sensor/rain_daily
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Weather Condition"
     id: weather_condition
     internal: true
-    topic: waveshare_display/input/sensor/current_weather_condition_num
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Upstairs Temperature"
     id: upstairs_temperature
     internal: true
-    topic: waveshare_display/input/sensor/upstairs_average_temperature
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Downstairs Temperature"
     id: downstairs_temperature
     internal: true
-    topic: waveshare_display/input/sensor/downstairs_average_temperature
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Basement Temperature"
     id: basement_temperature
     internal: true
-    topic: waveshare_display/input/sensor/basement_temperature_sensor
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Upstairs Humidity"
     id: upstairs_humidity
     internal: true
-    topic: waveshare_display/input/sensor/bedroom_humidity_sensor
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Downstairs Humidity"
     id: downstairs_humidity
     internal: true
-    topic: waveshare_display/input/sensor/family_room_humidity_sensor
-  - platform: mqtt_subscribe
+    update_interval: never
+  - platform: template
     name: "Basement Humidity"
     id: basement_humidity
     internal: true
-    topic: waveshare_display/input/sensor/basement_humidity_sensor
+    update_interval: never
     
 text_sensor:
-  - platform: mqtt_subscribe
-    name: "OTA Mode Payload"
-    id: ota_mode_payload
-    internal: true
-    topic: waveshare_display/input/input_boolean/waveshare_ota_mode
-    on_value:
-      then:
-        - binary_sensor.template.publish:
-            id: ota_mode
-            state: !lambda 'return id(ota_mode_payload).state == "on";'
-  - platform: mqtt_subscribe
-    name: "Sleep Mode Payload"
-    id: sleep_mode_payload
-    internal: true
-    topic: waveshare_display/input/input_boolean/waveshare_sleep_mode
-    on_value:
-      then:
-        - binary_sensor.template.publish:
-            id: sleep_mode
-            state: !lambda 'return id(sleep_mode_payload).state == "on";'
-  - platform: mqtt_subscribe
-    name: "Show QR Code Payload"
-    id: show_qr_code_payload
-    internal: true
-    topic: waveshare_display/input/input_boolean/waveshare_show_qr_code
-    on_value:
-      then:
-        - binary_sensor.template.publish:
-            id: show_qr_code
-            state: !lambda 'return id(show_qr_code_payload).state == "on";'
-  - platform: mqtt_subscribe
-    name: "Show Indoor Temp Payload"
-    id: show_indoor_temp_payload
-    internal: true
-    topic: waveshare_display/input/input_boolean/waveshare_show_indoor_temp
-    on_value:
-      then:
-        - binary_sensor.template.publish:
-            id: show_indoor_temp
-            state: !lambda 'return id(show_indoor_temp_payload).state == "on";'
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 1 Date"
     id: event_1_date
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_1_date
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 1 Name"
     id: event_1_name
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_1_name
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 1 Icon"
     id: event_1_icon
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_1_icon
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 2 Date"
     id: event_2_date
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_2_date
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 2 Name"
     id: event_2_name
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_2_name
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 2 Icon"
     id: event_2_icon
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_2_icon
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 3 Date"
     id: event_3_date
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_3_date
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 3 Name"
     id: event_3_name
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_3_name
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Upcoming Event 3 Icon"
     id: event_3_icon
     internal: true
-    topic: waveshare_display/input/sensor/upcoming_event_3_icon
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Forecast Conditions"
     id: forecast_conditions
     internal: true
-    topic: waveshare_display/input/sensor/forecast_condition_nums
     on_value:
       - if:
           condition:
@@ -284,11 +309,10 @@ text_sensor:
                 for(int f=0; f < 12; f += 2) {
                   id(forecast_nums).push_back( atoi(x.substr(f,2).c_str()) );
                 }
-  - platform: mqtt_subscribe
+  - platform: template
     name: "Notification String"
     id: notification_string
     internal: true
-    topic: waveshare_display/input/sensor/epaper_notifications
     on_value:
       - if:
           condition:

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -691,7 +691,7 @@ display:
         {"11", "Nov"},
         {"12", "Dec"}
       };
-      std::map<std::string, esphome::display::Image*> event_icon_map = {
+      std::map<std::string, esphome::image::Image*> event_icon_map = {
         {"baby-carriage", baby_carriage},
         {"bone", bone},
         {"cake-variant", cake_variant},
@@ -713,7 +713,7 @@ display:
         {"taco", taco},
         {"turkey", turkey}
       };
-      esphome::display::Image* weather_icon_map[16] = {
+      esphome::image::Image* weather_icon_map[16] = {
         clear_night,
         cloudy,
         exceptional,
@@ -731,7 +731,7 @@ display:
         windy_variant,
         windy
       };
-      esphome::display::Image* small_weather_icon_map[16] = {
+      esphome::image::Image* small_weather_icon_map[16] = {
         clear_night_small,
         cloudy_small,
         exceptional_small,
@@ -750,7 +750,7 @@ display:
         windy_small
       };
       #define notification_type_count 10
-      esphome::display::Image* notification_icon_map[notification_type_count*3] = {
+      esphome::image::Image* notification_icon_map[notification_type_count*3] = {
         trash_can_outline_large,
         dump_truck_large,
         recycle_large,
@@ -1072,7 +1072,7 @@ display:
           downstairs_humidity,
           basement_humidity
         };
-        esphome::display::Image* indoor_climate_icons[3] {
+        esphome::image::Image* indoor_climate_icons[3] {
           home_floor_2,
           home_floor_1,
           home_floor_b

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -138,7 +138,9 @@ http_request:
 
 ota:
   - platform: esphome
-    safe_mode: false
+
+safe_mode:
+  disabled: true
 
 switch:
   - platform: gpio

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -9,7 +9,9 @@ esphome:
   on_boot:
     priority: -100
     then:
-      - component.update: sntp_time
+      - wait_until:
+          wifi.connected:
+      - lambda: ESP_LOGI("ha_fetch", "Sending POST to HA...");
       - http_request.post:
           url: ${ha_base_url}/api/template
           capture_response: true
@@ -52,7 +54,10 @@ esphome:
           on_response:
             then:
               - lambda: |-
+                  ESP_LOGI("ha_fetch", "HTTP response status: %d", response->status_code);
+                  ESP_LOGI("ha_fetch", "Body: %.500s", body.c_str());
                   if (response->status_code != 200) {
+                    ESP_LOGE("ha_fetch", "Non-200 response, giving up");
                     id(tpl5111_done).turn_on();
                     return;
                   }
@@ -90,6 +95,8 @@ esphome:
                   });
           on_error:
             then:
+              - lambda: |-
+                  ESP_LOGE("ha_fetch", "HTTP request failed (connection error)");
               - switch.turn_on: tpl5111_done
       # Wait for some valid temp data
       - wait_until:
@@ -132,6 +139,9 @@ wifi:
 # Enable logging
 logger:
   level: DEBUG
+
+api:
+  reboot_timeout: 0s
 
 http_request:
   timeout: 10s
@@ -814,7 +824,7 @@ display:
         gauge_center_y = gauge_center_y_higher;
       }
       if (weather_condition_idx >= 0 && weather_condition_idx < 16)
-        it.image(weather_condition_x, weather_condition_y, id(&weather_icon_map[(int)weather_condition_idx]));
+        it.image(weather_condition_x, weather_condition_y, id(&weather_icon_map[(int)weather_condition_idx]), Color::WHITE, Color::BLACK);
 
       #define forecast_icon_side 32
       #define forecasts_radius 20
@@ -834,7 +844,7 @@ display:
         #define forecast_condition_num forecast_vector[i]
 
         if (forecast_condition_num >= 0 && forecast_condition_num < 16) {
-          it.image(forecast_icon_x, forecast_icon_y, id(&small_weather_icon_map[forecast_condition_num]));
+          it.image(forecast_icon_x, forecast_icon_y, id(&small_weather_icon_map[forecast_condition_num]), Color::WHITE, Color::BLACK);
         }
 
         it.circle(forecast_x, forecasts_y, forecasts_radius);
@@ -852,13 +862,13 @@ display:
       #define humidity_gauge_center_x 76
       it.filled_circle(humidity_gauge_center_x, gauge_center_y, gauge_radius, COLOR_ON);
       it.filled_circle(humidity_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness, COLOR_OFF);
-      it.image(humidity_gauge_center_x - 11, gauge_icon_height, id(humidity_small));
+      it.image(humidity_gauge_center_x - 11, gauge_icon_height, id(humidity_small), Color::WHITE, Color::BLACK);
 
       // Rain gauge
       #define rain_gauge_center_x 200
       it.filled_circle(rain_gauge_center_x, gauge_center_y, gauge_radius, COLOR_ON);
       it.filled_circle(rain_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness, COLOR_OFF);
-      it.image(rain_gauge_center_x - 11, gauge_icon_height, id(rain_small));
+      it.image(rain_gauge_center_x - 11, gauge_icon_height, id(rain_small), Color::WHITE, Color::BLACK);
 
       // Wind gauge
       #define wind_gauge_center_x 324
@@ -872,7 +882,7 @@ display:
         it.line(wind_gauge_center_x, gauge_center_y, wind_gauge_center_x+bearing_x, gauge_center_y+bearing_y);
       it.filled_circle(wind_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness-4, COLOR_OFF);
       // Wind Symbol
-      it.image(wind_gauge_center_x - 14, gauge_icon_height, id(wind_small));
+      it.image(wind_gauge_center_x - 14, gauge_icon_height, id(wind_small), Color::WHITE, Color::BLACK);
 
       char* current_temp;
       char* high_low_temps;
@@ -960,8 +970,8 @@ display:
       #define wifi_icon_top_margin_y (wifi_icon_top_y-4)
 
       if(id(show_qr_code).state) {
-        it.image(wifi_icon_left_y, wifi_icon_top_y, id(wifi_title));
-        it.image(it.get_width()-qr_code_side, it.get_height()-qr_code_side, id(wifi_qr));
+        it.image(wifi_icon_left_y, wifi_icon_top_y, id(wifi_title), Color::WHITE, Color::BLACK);
+        it.image(it.get_width()-qr_code_side, it.get_height()-qr_code_side, id(wifi_qr), Color::WHITE, Color::BLACK);
         // Divider line left of QR
         it.line(wifi_box_vertical_line_x, wifi_icon_top_margin_y, wifi_box_vertical_line_x, it.get_height());
       }
@@ -992,7 +1002,7 @@ display:
       #define event_first_item_top_y (screen_height - qr_code_side)
       #define event_item_y_spacing ((((screen_height - event_first_item_top_y) - event_icon_side_length*3 - 12)/2) + event_icon_side_length)
 
-      it.image(event_title_icon_x, wifi_icon_top_y, id(event_title));
+      it.image(event_title_icon_x, wifi_icon_top_y, id(event_title), Color::WHITE, Color::BLACK);
 
       esphome::text_sensor::TextSensor* event_dates[3] = {
         event_1_date,
@@ -1027,7 +1037,7 @@ display:
         int event_text_center_y = (event_item_top_y + (event_icon_side_length/2));
         // Ensure icon is in the map first
         if(event_icon_map.count(evt_icon_str)) {
-          it.image(event_item_left_x, event_item_top_y, id(&event_icon_map[evt_icon_str]));
+          it.image(event_item_left_x, event_item_top_y, id(&event_icon_map[evt_icon_str]), Color::WHITE, Color::BLACK);
         }  
         if(evt_date_str.length() == 5) {    
           if(month_map.count(evt_date_str.substr(0,2))) {
@@ -1059,8 +1069,8 @@ display:
       #define climate_icon_top_y 8
 
       if (id(show_indoor_temp).state) {
-        it.image(temp_icon_left_x, climate_icon_top_y, id(thermometer_small));
-        it.image(humidity_icon_left_x, climate_icon_top_y, id(humidity_small));
+        it.image(temp_icon_left_x, climate_icon_top_y, id(thermometer_small), Color::WHITE, Color::BLACK);
+        it.image(humidity_icon_left_x, climate_icon_top_y, id(humidity_small), Color::WHITE, Color::BLACK);
 
         esphome::sensor::Sensor* indoor_temps[3] {
           upstairs_temperature,
@@ -1080,7 +1090,7 @@ display:
 
         for (int k=0; k<3; k++) {
           #define floor_item_current_top_y (floor_icon_top_y + floor_icon_y_spacing*k)
-          it.image(floor_icon_left_x, floor_item_current_top_y, id(&indoor_climate_icons[k]));
+          it.image(floor_icon_left_x, floor_item_current_top_y, id(&indoor_climate_icons[k]), Color::WHITE, Color::BLACK);
           char* floor_temp;
           asprintf(&floor_temp, "%.0f", id(&indoor_temps[k])->state);
           char* floor_humidity;
@@ -1142,7 +1152,7 @@ display:
           int icon_x = (notification_area_left_x + (notification_area_width - row_width)/2);
           for (int m = start_icon_idx; m < start_icon_idx + row_icon_count; m++) {
             #define notification_icon_image id(&notification_icon_map[notification_vector[m] + notification_icon_map_idx_skip])
-            it.image(icon_x, icon_y, notification_icon_image);
+            it.image(icon_x, icon_y, notification_icon_image, Color::WHITE, Color::BLACK);
             icon_x += icon_size + notification_icon_x_margin;
           }
           icon_y += icon_size + notification_icon_y_margin;

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -191,7 +191,7 @@ binary_sensor:
 sensor:
   - platform: adc
     pin: A13
-    attenuation: 11db
+    attenuation: 12db
     name: "ePaper Battery Voltage"
     id: battery_voltage
     filters:
@@ -345,200 +345,295 @@ image:
   # Weather conditions
   - file: "icon-bmp/weather/clear-night.bmp"
     id: clear_night
+    type: BINARY
   - file: "icon-bmp/weather/cloudy.bmp"
     id: cloudy
+    type: BINARY
   - file: "icon-bmp/weather/exceptional.bmp"
     id: exceptional
+    type: BINARY
   - file: "icon-bmp/weather/fog.bmp"
     id: fog
+    type: BINARY
   - file: "icon-bmp/weather/hail.bmp"
     id: hail
+    type: BINARY
   - file: "icon-bmp/weather/lightning-rainy.bmp"
     id: lightning_rainy
+    type: BINARY
   - file: "icon-bmp/weather/lightning.bmp"
     id: lightning
+    type: BINARY
   - file: "icon-bmp/weather/partlycloudy-day.bmp"
     id: partlycloudy_day
+    type: BINARY
   - file: "icon-bmp/weather/partlycloudy-night.bmp"
     id: partlycloudy_night
+    type: BINARY
   - file: "icon-bmp/weather/pouring.bmp"
     id: pouring
+    type: BINARY
   - file: "icon-bmp/weather/rainy.bmp"
     id: rainy
+    type: BINARY
   - file: "icon-bmp/weather/snowy-rainy.bmp"
     id: snowy_rainy
+    type: BINARY
   - file: "icon-bmp/weather/snowy.bmp"
     id: snowy
+    type: BINARY
   - file: "icon-bmp/weather/sunny.bmp"
     id: sunny
+    type: BINARY
   - file: "icon-bmp/weather/windy-variant.bmp"
     id: windy_variant
+    type: BINARY
   - file: "icon-bmp/weather/windy.bmp"
     id: windy
+    type: BINARY
   # Small weather condition icons
   - file: "icon-bmp/weather-small/clear-night-small.bmp"
     id: clear_night_small
+    type: BINARY
   - file: "icon-bmp/weather-small/cloudy-small.bmp"
     id: cloudy_small
+    type: BINARY
   - file: "icon-bmp/weather-small/exceptional-small.bmp"
     id: exceptional_small
+    type: BINARY
   - file: "icon-bmp/weather-small/fog-small.bmp"
     id: fog_small
+    type: BINARY
   - file: "icon-bmp/weather-small/hail-small.bmp"
     id: hail_small
+    type: BINARY
   - file: "icon-bmp/weather-small/lightning-rainy-small.bmp"
     id: lightning_rainy_small
+    type: BINARY
   - file: "icon-bmp/weather-small/lightning-small.bmp"
     id: lightning_small
+    type: BINARY
   - file: "icon-bmp/weather-small/partlycloudy-day-small.bmp"
     id: partlycloudy_day_small
+    type: BINARY
   - file: "icon-bmp/weather-small/partlycloudy-night-small.bmp"
     id: partlycloudy_night_small
+    type: BINARY
   - file: "icon-bmp/weather-small/pouring-small.bmp"
     id: pouring_small
+    type: BINARY
   - file: "icon-bmp/weather-small/rainy-small.bmp"
     id: rainy_small
+    type: BINARY
   - file: "icon-bmp/weather-small/snowy-rainy-small.bmp"
     id: snowy_rainy_small
+    type: BINARY
   - file: "icon-bmp/weather-small/snowy-small.bmp"
     id: snowy_small
+    type: BINARY
   - file: "icon-bmp/weather-small/sunny-small.bmp"
     id: sunny_small
+    type: BINARY
   - file: "icon-bmp/weather-small/windy-variant-small.bmp"
     id: windy_variant_small
+    type: BINARY
   - file: "icon-bmp/weather-small/windy-small.bmp"
     id: windy_small
+    type: BINARY
   # Event icons
   - file: "icon-bmp/events/baby-carriage.bmp"
     id: baby_carriage
+    type: BINARY
   - file: "icon-bmp/events/bone.bmp"
     id: bone
+    type: BINARY
   - file: "icon-bmp/events/cake-variant.bmp"
     id: cake_variant
+    type: BINARY
   - file: "icon-bmp/events/calendar.bmp"
     id: calendar
+    type: BINARY
   - file: "icon-bmp/events/clover.bmp"
     id: clover
+    type: BINARY
   - file: "icon-bmp/events/egg-easter.bmp"
     id: egg_easter
+    type: BINARY
   - file: "icon-bmp/events/flag.bmp"
     id: flag
+    type: BINARY
   - file: "icon-bmp/events/football.bmp"
     id: football
+    type: BINARY
   - file: "icon-bmp/events/halloween.bmp"
     id: halloween
+    type: BINARY
   - file: "icon-bmp/events/heart-multiple.bmp"
     id: heart_multiple
+    type: BINARY
   - file: "icon-bmp/events/heart.bmp"
     id: heart
+    type: BINARY
   - file: "icon-bmp/events/history.bmp"
     id: history
+    type: BINARY
   - file: "icon-bmp/events/history2.bmp"
     id: history2
+    type: BINARY
   - file: "icon-bmp/events/microphone.bmp"
     id: microphone
+    type: BINARY
   - file: "icon-bmp/events/mother-heart.bmp"
     id: mother_heart
+    type: BINARY
   - file: "icon-bmp/events/mustache.bmp"
     id: mustache
+    type: BINARY
   - file: "icon-bmp/events/party-popper.bmp"
     id: party_popper
+    type: BINARY
   - file: "icon-bmp/events/pine-tree.bmp"
     id: pine_tree
+    type: BINARY
   - file: "icon-bmp/events/shield-star.bmp"
     id: shield_star
+    type: BINARY
   - file: "icon-bmp/events/shovel.bmp"
     id: shovel
+    type: BINARY
   - file: "icon-bmp/events/star.bmp"
     id: star
+    type: BINARY
   - file: "icon-bmp/events/taco.bmp"
     id: taco
+    type: BINARY
   - file: "icon-bmp/events/turkey.bmp"
     id: turkey
+    type: BINARY
   # Notification Large
   - file: "icon-bmp/notification-large/dishwasher-alert.bmp"
     id: dishwasher_alert_large
+    type: BINARY
   - file: "icon-bmp/notification-large/dog-bowl.bmp"
     id: dog_bowl_large
+    type: BINARY
   - file: "icon-bmp/notification-large/dump-truck.bmp"
     id: dump_truck_large
+    type: BINARY
   - file: "icon-bmp/notification-large/recycle.bmp"
     id: recycle_large
+    type: BINARY
   - file: "icon-bmp/notification-large/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_large
+    type: BINARY
   - file: "icon-bmp/notification-large/trash-can-outline.bmp"
     id: trash_can_outline_large
+    type: BINARY
   - file: "icon-bmp/notification-large/washing-machine-alert.bmp"
     id: washing_machine_alert_large
+    type: BINARY
   - file: "icon-bmp/notification-large/wifi-alert.bmp"
     id: wifi_alert_large
+    type: BINARY
   - file: "icon-bmp/notification-large/battery-low.bmp"
     id: battery_low_large
+    type: BINARY
   - file: "icon-bmp/notification-large/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_large
+    type: BINARY
   # Notification Medium
   - file: "icon-bmp/notification-med/dishwasher-alert.bmp"
     id: dishwasher_alert_med
+    type: BINARY
   - file: "icon-bmp/notification-med/dog-bowl.bmp"
     id: dog_bowl_med
+    type: BINARY
   - file: "icon-bmp/notification-med/dump-truck.bmp"
     id: dump_truck_med
+    type: BINARY
   - file: "icon-bmp/notification-med/recycle.bmp"
     id: recycle_med
+    type: BINARY
   - file: "icon-bmp/notification-med/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_med
+    type: BINARY
   - file: "icon-bmp/notification-med/trash-can-outline.bmp"
     id: trash_can_outline_med
+    type: BINARY
   - file: "icon-bmp/notification-med/washing-machine-alert.bmp"
     id: washing_machine_alert_med
+    type: BINARY
   - file: "icon-bmp/notification-med/wifi-alert.bmp"
     id: wifi_alert_med
+    type: BINARY
   - file: "icon-bmp/notification-med/battery-low.bmp"
     id: battery_low_med
+    type: BINARY
   - file: "icon-bmp/notification-med/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_med
+    type: BINARY
   # Notification Small
   - file: "icon-bmp/notification-small/dishwasher-alert.bmp"
     id: dishwasher_alert_small
+    type: BINARY
   - file: "icon-bmp/notification-small/dog-bowl.bmp"
     id: dog_bowl_small
+    type: BINARY
   - file: "icon-bmp/notification-small/dump-truck.bmp"
     id: dump_truck_small
+    type: BINARY
   - file: "icon-bmp/notification-small/recycle.bmp"
     id: recycle_small
+    type: BINARY
   - file: "icon-bmp/notification-small/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_small
+    type: BINARY
   - file: "icon-bmp/notification-small/trash-can-outline.bmp"
     id: trash_can_outline_small
+    type: BINARY
   - file: "icon-bmp/notification-small/washing-machine-alert.bmp"
     id: washing_machine_alert_small
+    type: BINARY
   - file: "icon-bmp/notification-small/wifi-alert.bmp"
     id: wifi_alert_small
+    type: BINARY
   - file: "icon-bmp/notification-small/battery-low.bmp"
     id: battery_low_small
+    type: BINARY
   - file: "icon-bmp/notification-small/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_small
+    type: BINARY
   # Other icons
   - file: "icon-bmp/weather-small/wind-small.bmp"
     id: wind_small
+    type: BINARY
   - file: "icon-bmp/weather-small/water-percent.bmp"
     id: humidity_small
+    type: BINARY
   - file: "icon-bmp/weather-small/rain-small.bmp"
     id: rain_small
+    type: BINARY
   - file: "icon-bmp/wifi-qrcode.bmp"
     id: wifi_qr
+    type: BINARY
   - file: "icon-bmp/events/calendar.bmp"
     id: event_title
+    type: BINARY
   - file: "icon-bmp/wifi-lock.bmp"
     id: wifi_title
+    type: BINARY
   - file: "icon-bmp/home-floor-1.bmp"
     id: home_floor_1
+    type: BINARY
   - file: "icon-bmp/home-floor-2.bmp"
     id: home_floor_2
+    type: BINARY
   - file: "icon-bmp/home-floor-b.bmp"
     id: home_floor_b
+    type: BINARY
   - file: "icon-bmp/weather-small/thermometer.bmp"
     id: thermometer_small
+    type: BINARY
 
 font:
   - file: "RobotoCondensed-Bold.ttf"

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -109,12 +109,6 @@ esphome:
                   } else {
                     id(tpl5111_done).turn_on();
                   }
-      # Wait for some valid temp data
-      - wait_until:
-          sensor.in_range:
-            id: outdoor_temperature
-            above: -460
-      - delay: 1s
       - component.update: battery_voltage
       - lambda: |-
           // Add battery-low notification locally if voltage is below threshold
@@ -128,13 +122,23 @@ esphome:
       - wait_until:
           time.has_time:
       - component.update: epaper_display
-      # Wait for display update cycle
-      - delay: 6s
+      # The driver may time out before the display starts its visual refresh.
+      # Wait for BUSY to go low (refresh started), then high (refresh complete).
+      - wait_until:
+          condition:
+            binary_sensor.is_off: display_busy
+          timeout: 30s
+      - wait_until:
+          condition:
+            binary_sensor.is_on: display_busy
+          timeout: 30s
+      - delay: 500ms
       # Go back to sleep once display has updated
       - if:
           condition:
             binary_sensor.is_off: ota_mode
           then:
+            - lambda: global_preferences->sync();  # flush restore_value globals to NVS before power cut
             - switch.turn_on: tpl5111_done
 
 esp32:
@@ -175,6 +179,12 @@ time:
     timezone: America/New_York
 
 binary_sensor:
+  - platform: gpio
+    pin:
+      number: 4
+      allow_other_uses: true
+    id: display_busy
+    internal: true
   - platform: template
     name: "OTA Mode"
     id: ota_mode
@@ -780,7 +790,9 @@ display:
     id: epaper_display
     cs_pin: 22
     dc_pin: 23
-    busy_pin: 4
+    busy_pin:
+      number: 4
+      allow_other_uses: true
     reset_pin: 21
     model: 7.50inV2
     spi_id: waveshare_spi

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -48,7 +48,8 @@ esphome:
                 'event_3_name': states('sensor.upcoming_event_3_name'),
                 'event_3_icon': states('sensor.upcoming_event_3_icon'),
                 'forecast_conditions': states('sensor.forecast_condition_nums'),
-                'notification_string': states('sensor.epaper_notifications')
+                'notification_string': states('sensor.epaper_notifications'),
+                'timestamp': now().timestamp() | int
               } | tojson }}
           on_response:
             then:
@@ -96,6 +97,8 @@ esphome:
                     id(event_3_icon).publish_state(root["event_3_icon"].as<std::string>());
                     id(forecast_conditions).publish_state(root["forecast_conditions"].as<std::string>());
                     id(notification_string).publish_state(root["notification_string"].as<std::string>());
+                    struct timeval tv = { .tv_sec = root["timestamp"].as<time_t>(), .tv_usec = 0 };
+                    settimeofday(&tv, nullptr);
                     return true;
                   });
           on_error:
@@ -119,19 +122,7 @@ esphome:
             }
             if (!already_present) id(notification_nums).push_back(8);
           }
-      - wait_until:
-          time.has_time:
       - component.update: epaper_display
-      # The driver may time out before the display starts its visual refresh.
-      # Wait for BUSY to go low (refresh started), then high (refresh complete).
-      - wait_until:
-          condition:
-            binary_sensor.is_off: display_busy
-          timeout: 30s
-      - wait_until:
-          condition:
-            binary_sensor.is_on: display_busy
-          timeout: 30s
       - delay: 500ms
       # Go back to sleep once display has updated
       - if:
@@ -177,6 +168,9 @@ time:
   - platform: sntp
     id: sntp_time
     timezone: America/New_York
+    servers:
+      - 192.168.1.1
+      - 0.pool.ntp.org
 
 binary_sensor:
   - platform: gpio
@@ -185,6 +179,8 @@ binary_sensor:
       allow_other_uses: true
     id: display_busy
     internal: true
+  - platform: status
+    name: "ePaper Status"
   - platform: template
     name: "OTA Mode"
     id: ota_mode
@@ -207,6 +203,13 @@ binary_sensor:
     name: "Show Indoor Temp"
     id: show_indoor_temp
     internal: true
+  - platform: template
+    name: "ePaper Battery Low"
+    id: battery_low
+    device_class: battery
+    lambda: |-
+      if (id(battery_voltage).state < 3.35) return true;
+      return false;
 
 sensor:
   - platform: adc
@@ -793,6 +796,7 @@ display:
     busy_pin:
       number: 4
       allow_other_uses: true
+      inverted: true
     reset_pin: 21
     model: 7.50inV2
     spi_id: waveshare_spi

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -147,18 +147,6 @@ switch:
     pin: 27
     id: tpl5111_done
     restore_mode: ALWAYS_OFF
-  # Epaper display doesn't turn back on
-  #   after sleep while on lipo power 
-  #   unless this switch is defined.
-  #   Not sure why!
-  - platform: gpio
-    pin:
-      number: 21
-      inverted: yes
-      ignore_pin_validation_error: true
-    id: reset_switch
-    internal: true
-    name: "Display Reset Pin"
 
 time:
   - platform: sntp
@@ -673,9 +661,7 @@ display:
     cs_pin: 22
     dc_pin: 23
     busy_pin: 4
-    reset_pin:
-      number: 21
-      ignore_pin_validation_error: true
+    reset_pin: 21
     model: 7.50inV2
     spi_id: waveshare_spi
     update_interval: never

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  ha_base_url: http://192.168.1.1:8123
+
 esphome:
   name: waveshare_display
   platform: ESP32
@@ -10,7 +13,7 @@ esphome:
     then:
       - component.update: sntp_time
       - http_request.post:
-          url: http://192.168.1.1:8123/api/template
+          url: ${ha_base_url}/api/template
           capture_response: true
           request_headers:
             Authorization: !secret ha_token

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -155,6 +155,7 @@ switch:
     pin:
       number: 21
       inverted: yes
+      ignore_pin_validation_error: true
     id: reset_switch
     internal: true
     name: "Display Reset Pin"
@@ -672,7 +673,9 @@ display:
     cs_pin: 22
     dc_pin: 23
     busy_pin: 4
-    reset_pin: 21
+    reset_pin:
+      number: 21
+      ignore_pin_validation_error: true
     model: 7.50inV2
     spi_id: waveshare_spi
     update_interval: never

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -57,8 +57,14 @@ esphome:
                   ESP_LOGI("ha_fetch", "HTTP response status: %d", response->status_code);
                   ESP_LOGI("ha_fetch", "Body: %.500s", body.c_str());
                   if (response->status_code != 200) {
-                    ESP_LOGE("ha_fetch", "Non-200 response, giving up");
-                    id(tpl5111_done).turn_on();
+                    ESP_LOGE("ha_fetch", "Non-200 response: %d", response->status_code);
+                    if (id(last_ota_mode)) {
+                      ESP_LOGI("ha_fetch", "Last OTA mode ON, staying awake");
+                      id(ota_mode).publish_state(true);
+                      id(outdoor_temperature).publish_state(0);
+                    } else {
+                      id(tpl5111_done).turn_on();
+                    }
                     return;
                   }
                   json::parse_json(body, [](JsonObject root) -> bool {
@@ -76,7 +82,9 @@ esphome:
                     id(upstairs_humidity).publish_state(root["upstairs_humidity"].as<float>());
                     id(downstairs_humidity).publish_state(root["downstairs_humidity"].as<float>());
                     id(basement_humidity).publish_state(root["basement_humidity"].as<float>());
-                    id(ota_mode).publish_state(root["ota_mode"].as<bool>());
+                    bool ota = root["ota_mode"].as<bool>();
+                    id(last_ota_mode) = ota;
+                    id(ota_mode).publish_state(ota);
                     id(sleep_mode).publish_state(root["sleep_mode"].as<bool>());
                     id(show_qr_code).publish_state(root["show_qr_code"].as<bool>());
                     id(show_indoor_temp).publish_state(root["show_indoor_temp"].as<bool>());
@@ -97,7 +105,13 @@ esphome:
             then:
               - lambda: |-
                   ESP_LOGE("ha_fetch", "HTTP request failed (connection error)");
-              - switch.turn_on: tpl5111_done
+                  if (id(last_ota_mode)) {
+                    ESP_LOGI("ha_fetch", "Last OTA mode ON, staying awake");
+                    id(ota_mode).publish_state(true);
+                    id(outdoor_temperature).publish_state(0);
+                  } else {
+                    id(tpl5111_done).turn_on();
+                  }
       # Wait for some valid temp data
       - wait_until:
           sensor.in_range:
@@ -339,6 +353,10 @@ globals:
     type: std::vector<int>
   - id: notification_nums
     type: std::vector<int>
+  - id: last_ota_mode
+    type: bool
+    restore_value: true
+    initial_value: 'false'
 
 image:
   # Weather conditions

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  ha_base_url: http://192.168.1.1:8123
+  ha_base_url: !secret ha_base_url
 
 esphome:
   name: waveshare_display
@@ -122,8 +122,8 @@ esphome:
             - switch.turn_on: tpl5111_done
 
 wifi:
-  ssid: "ssid"
-  password: "password"
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
   fast_connect: true
 
 # Enable logging

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -3,8 +3,6 @@ substitutions:
 
 esphome:
   name: waveshare_display
-  platform: ESP32
-  board: featheresp32
   includes:
     # Load in std libs (map, vector)
     - OtherLibs.h
@@ -120,6 +118,11 @@ esphome:
             binary_sensor.is_off: ota_mode
           then:
             - switch.turn_on: tpl5111_done
+
+esp32:
+  board: featheresp32
+  framework:
+    type: arduino
 
 wifi:
   ssid: !secret wifi_ssid

--- a/waveshare.yaml
+++ b/waveshare.yaml
@@ -11,7 +11,6 @@ esphome:
     then:
       - wait_until:
           wifi.connected:
-      - lambda: ESP_LOGI("ha_fetch", "Sending POST to HA...");
       - http_request.post:
           url: ${ha_base_url}/api/template
           capture_response: true
@@ -54,8 +53,6 @@ esphome:
           on_response:
             then:
               - lambda: |-
-                  ESP_LOGI("ha_fetch", "HTTP response status: %d", response->status_code);
-                  ESP_LOGI("ha_fetch", "Body: %.500s", body.c_str());
                   if (response->status_code != 200) {
                     ESP_LOGE("ha_fetch", "Non-200 response: %d", response->status_code);
                     if (id(last_ota_mode)) {
@@ -363,294 +360,389 @@ image:
   - file: "icon-bmp/weather/clear-night.bmp"
     id: clear_night
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/cloudy.bmp"
     id: cloudy
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/exceptional.bmp"
     id: exceptional
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/fog.bmp"
     id: fog
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/hail.bmp"
     id: hail
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/lightning-rainy.bmp"
     id: lightning_rainy
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/lightning.bmp"
     id: lightning
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/partlycloudy-day.bmp"
     id: partlycloudy_day
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/partlycloudy-night.bmp"
     id: partlycloudy_night
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/pouring.bmp"
     id: pouring
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/rainy.bmp"
     id: rainy
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/snowy-rainy.bmp"
     id: snowy_rainy
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/snowy.bmp"
     id: snowy
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/sunny.bmp"
     id: sunny
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/windy-variant.bmp"
     id: windy_variant
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather/windy.bmp"
     id: windy
     type: BINARY
+    invert_alpha: true
   # Small weather condition icons
   - file: "icon-bmp/weather-small/clear-night-small.bmp"
     id: clear_night_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/cloudy-small.bmp"
     id: cloudy_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/exceptional-small.bmp"
     id: exceptional_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/fog-small.bmp"
     id: fog_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/hail-small.bmp"
     id: hail_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/lightning-rainy-small.bmp"
     id: lightning_rainy_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/lightning-small.bmp"
     id: lightning_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/partlycloudy-day-small.bmp"
     id: partlycloudy_day_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/partlycloudy-night-small.bmp"
     id: partlycloudy_night_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/pouring-small.bmp"
     id: pouring_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/rainy-small.bmp"
     id: rainy_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/snowy-rainy-small.bmp"
     id: snowy_rainy_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/snowy-small.bmp"
     id: snowy_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/sunny-small.bmp"
     id: sunny_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/windy-variant-small.bmp"
     id: windy_variant_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/windy-small.bmp"
     id: windy_small
     type: BINARY
+    invert_alpha: true
   # Event icons
   - file: "icon-bmp/events/baby-carriage.bmp"
     id: baby_carriage
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/bone.bmp"
     id: bone
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/cake-variant.bmp"
     id: cake_variant
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/calendar.bmp"
     id: calendar
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/clover.bmp"
     id: clover
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/egg-easter.bmp"
     id: egg_easter
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/flag.bmp"
     id: flag
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/football.bmp"
     id: football
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/halloween.bmp"
     id: halloween
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/heart-multiple.bmp"
     id: heart_multiple
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/heart.bmp"
     id: heart
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/history.bmp"
     id: history
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/history2.bmp"
     id: history2
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/microphone.bmp"
     id: microphone
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/mother-heart.bmp"
     id: mother_heart
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/mustache.bmp"
     id: mustache
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/party-popper.bmp"
     id: party_popper
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/pine-tree.bmp"
     id: pine_tree
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/shield-star.bmp"
     id: shield_star
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/shovel.bmp"
     id: shovel
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/star.bmp"
     id: star
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/taco.bmp"
     id: taco
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/turkey.bmp"
     id: turkey
     type: BINARY
+    invert_alpha: true
   # Notification Large
   - file: "icon-bmp/notification-large/dishwasher-alert.bmp"
     id: dishwasher_alert_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/dog-bowl.bmp"
     id: dog_bowl_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/dump-truck.bmp"
     id: dump_truck_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/recycle.bmp"
     id: recycle_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/trash-can-outline.bmp"
     id: trash_can_outline_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/washing-machine-alert.bmp"
     id: washing_machine_alert_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/wifi-alert.bmp"
     id: wifi_alert_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/battery-low.bmp"
     id: battery_low_large
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-large/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_large
     type: BINARY
+    invert_alpha: true
   # Notification Medium
   - file: "icon-bmp/notification-med/dishwasher-alert.bmp"
     id: dishwasher_alert_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/dog-bowl.bmp"
     id: dog_bowl_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/dump-truck.bmp"
     id: dump_truck_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/recycle.bmp"
     id: recycle_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/trash-can-outline.bmp"
     id: trash_can_outline_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/washing-machine-alert.bmp"
     id: washing_machine_alert_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/wifi-alert.bmp"
     id: wifi_alert_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/battery-low.bmp"
     id: battery_low_med
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-med/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_med
     type: BINARY
+    invert_alpha: true
   # Notification Small
   - file: "icon-bmp/notification-small/dishwasher-alert.bmp"
     id: dishwasher_alert_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/dog-bowl.bmp"
     id: dog_bowl_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/dump-truck.bmp"
     id: dump_truck_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/recycle.bmp"
     id: recycle_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/robot-vacuum-variant.bmp"
     id: robot_vacuum_variant_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/trash-can-outline.bmp"
     id: trash_can_outline_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/washing-machine-alert.bmp"
     id: washing_machine_alert_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/wifi-alert.bmp"
     id: wifi_alert_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/battery-low.bmp"
     id: battery_low_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/notification-small/tumble-dryer-alert.bmp"
     id: tumble_dryer_alert_small
     type: BINARY
+    invert_alpha: true
   # Other icons
   - file: "icon-bmp/weather-small/wind-small.bmp"
     id: wind_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/water-percent.bmp"
     id: humidity_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/rain-small.bmp"
     id: rain_small
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/wifi-qrcode.bmp"
     id: wifi_qr
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/events/calendar.bmp"
     id: event_title
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/wifi-lock.bmp"
     id: wifi_title
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/home-floor-1.bmp"
     id: home_floor_1
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/home-floor-2.bmp"
     id: home_floor_2
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/home-floor-b.bmp"
     id: home_floor_b
     type: BINARY
+    invert_alpha: true
   - file: "icon-bmp/weather-small/thermometer.bmp"
     id: thermometer_small
     type: BINARY
+    invert_alpha: true
 
 font:
   - file: "RobotoCondensed-Bold.ttf"
@@ -842,7 +934,7 @@ display:
         gauge_center_y = gauge_center_y_higher;
       }
       if (weather_condition_idx >= 0 && weather_condition_idx < 16)
-        it.image(weather_condition_x, weather_condition_y, id(&weather_icon_map[(int)weather_condition_idx]), Color::WHITE, Color::BLACK);
+        it.image(weather_condition_x, weather_condition_y, id(&weather_icon_map[(int)weather_condition_idx]));
 
       #define forecast_icon_side 32
       #define forecasts_radius 20
@@ -862,7 +954,7 @@ display:
         #define forecast_condition_num forecast_vector[i]
 
         if (forecast_condition_num >= 0 && forecast_condition_num < 16) {
-          it.image(forecast_icon_x, forecast_icon_y, id(&small_weather_icon_map[forecast_condition_num]), Color::WHITE, Color::BLACK);
+          it.image(forecast_icon_x, forecast_icon_y, id(&small_weather_icon_map[forecast_condition_num]));
         }
 
         it.circle(forecast_x, forecasts_y, forecasts_radius);
@@ -880,13 +972,13 @@ display:
       #define humidity_gauge_center_x 76
       it.filled_circle(humidity_gauge_center_x, gauge_center_y, gauge_radius, COLOR_ON);
       it.filled_circle(humidity_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness, COLOR_OFF);
-      it.image(humidity_gauge_center_x - 11, gauge_icon_height, id(humidity_small), Color::WHITE, Color::BLACK);
+      it.image(humidity_gauge_center_x - 11, gauge_icon_height, id(humidity_small));
 
       // Rain gauge
       #define rain_gauge_center_x 200
       it.filled_circle(rain_gauge_center_x, gauge_center_y, gauge_radius, COLOR_ON);
       it.filled_circle(rain_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness, COLOR_OFF);
-      it.image(rain_gauge_center_x - 11, gauge_icon_height, id(rain_small), Color::WHITE, Color::BLACK);
+      it.image(rain_gauge_center_x - 11, gauge_icon_height, id(rain_small));
 
       // Wind gauge
       #define wind_gauge_center_x 324
@@ -900,7 +992,7 @@ display:
         it.line(wind_gauge_center_x, gauge_center_y, wind_gauge_center_x+bearing_x, gauge_center_y+bearing_y);
       it.filled_circle(wind_gauge_center_x, gauge_center_y, gauge_radius-gauge_thickness-4, COLOR_OFF);
       // Wind Symbol
-      it.image(wind_gauge_center_x - 14, gauge_icon_height, id(wind_small), Color::WHITE, Color::BLACK);
+      it.image(wind_gauge_center_x - 14, gauge_icon_height, id(wind_small));
 
       char* current_temp;
       char* high_low_temps;
@@ -988,8 +1080,8 @@ display:
       #define wifi_icon_top_margin_y (wifi_icon_top_y-4)
 
       if(id(show_qr_code).state) {
-        it.image(wifi_icon_left_y, wifi_icon_top_y, id(wifi_title), Color::WHITE, Color::BLACK);
-        it.image(it.get_width()-qr_code_side, it.get_height()-qr_code_side, id(wifi_qr), Color::WHITE, Color::BLACK);
+        it.image(wifi_icon_left_y, wifi_icon_top_y, id(wifi_title));
+        it.image(it.get_width()-qr_code_side, it.get_height()-qr_code_side, id(wifi_qr));
         // Divider line left of QR
         it.line(wifi_box_vertical_line_x, wifi_icon_top_margin_y, wifi_box_vertical_line_x, it.get_height());
       }
@@ -1020,7 +1112,7 @@ display:
       #define event_first_item_top_y (screen_height - qr_code_side)
       #define event_item_y_spacing ((((screen_height - event_first_item_top_y) - event_icon_side_length*3 - 12)/2) + event_icon_side_length)
 
-      it.image(event_title_icon_x, wifi_icon_top_y, id(event_title), Color::WHITE, Color::BLACK);
+      it.image(event_title_icon_x, wifi_icon_top_y, id(event_title));
 
       esphome::text_sensor::TextSensor* event_dates[3] = {
         event_1_date,
@@ -1055,7 +1147,7 @@ display:
         int event_text_center_y = (event_item_top_y + (event_icon_side_length/2));
         // Ensure icon is in the map first
         if(event_icon_map.count(evt_icon_str)) {
-          it.image(event_item_left_x, event_item_top_y, id(&event_icon_map[evt_icon_str]), Color::WHITE, Color::BLACK);
+          it.image(event_item_left_x, event_item_top_y, id(&event_icon_map[evt_icon_str]));
         }  
         if(evt_date_str.length() == 5) {    
           if(month_map.count(evt_date_str.substr(0,2))) {
@@ -1087,8 +1179,8 @@ display:
       #define climate_icon_top_y 8
 
       if (id(show_indoor_temp).state) {
-        it.image(temp_icon_left_x, climate_icon_top_y, id(thermometer_small), Color::WHITE, Color::BLACK);
-        it.image(humidity_icon_left_x, climate_icon_top_y, id(humidity_small), Color::WHITE, Color::BLACK);
+        it.image(temp_icon_left_x, climate_icon_top_y, id(thermometer_small));
+        it.image(humidity_icon_left_x, climate_icon_top_y, id(humidity_small));
 
         esphome::sensor::Sensor* indoor_temps[3] {
           upstairs_temperature,
@@ -1108,7 +1200,7 @@ display:
 
         for (int k=0; k<3; k++) {
           #define floor_item_current_top_y (floor_icon_top_y + floor_icon_y_spacing*k)
-          it.image(floor_icon_left_x, floor_item_current_top_y, id(&indoor_climate_icons[k]), Color::WHITE, Color::BLACK);
+          it.image(floor_icon_left_x, floor_item_current_top_y, id(&indoor_climate_icons[k]));
           char* floor_temp;
           asprintf(&floor_temp, "%.0f", id(&indoor_temps[k])->state);
           char* floor_humidity;
@@ -1170,7 +1262,7 @@ display:
           int icon_x = (notification_area_left_x + (notification_area_width - row_width)/2);
           for (int m = start_icon_idx; m < start_icon_idx + row_icon_count; m++) {
             #define notification_icon_image id(&notification_icon_map[notification_vector[m] + notification_icon_map_idx_skip])
-            it.image(icon_x, icon_y, notification_icon_image, Color::WHITE, Color::BLACK);
+            it.image(icon_x, icon_y, notification_icon_image);
             icon_x += icon_size + notification_icon_x_margin;
           }
           icon_y += icon_size + notification_icon_y_margin;


### PR DESCRIPTION
## Summary

Replaces the MQTT broker dependency with direct calls to the Home Assistant REST API (`POST /api/template`). On boot, the device makes a single HTTP request that fetches all sensor values at once as a Jinja2-rendered JSON blob, eliminating the need for an MQTT broker and individual topic subscriptions.

### Why

MQTT with retained messages was used so sensor values were delivered immediately on subscription. The HA native API didn't work because ESPHome acts as the server — HA must discover it first, which is too slow for the sleep/wake cycle. The REST API gives the same "device connects outbound and gets data immediately" behavior without requiring a broker.

### Changes

- **`http_request:` component** replaces `mqtt:` block; a single `POST /api/template` with a Bearer token fetches all sensor values as JSON
- **`api:` block** added with `reboot_timeout: 0s` for OTA/remote logging without blocking the sleep cycle
- **`on_boot`** now waits for WiFi, fires one HTTP POST, parses the JSON response, and publishes state to all sensors in one lambda
- **All `mqtt_subscribe` sensors replaced** with `platform: template` / `update_interval: never` — IDs unchanged so display logic is unaffected
- **`invert_alpha: true`** added to all ~95 binary images to fix color inversion introduced by the now-required `type: BINARY` field in newer ESPHome
- **NVS-persisted `last_ota_mode` global** — on HTTP failure, the device checks the last-known OTA mode and stays awake if it was on, preventing the device from sleeping and becoming un-flashable when HA is temporarily unreachable
- **ESPHome compatibility fixes**: `ota:` platform key, `image: type:` field, `Image` namespace (`esphome::image::` vs `esphome::display::`), ADC attenuation (`12db`), pin conflict removal

### Setup

Add to `secrets.yaml`:
```yaml
ha_base_url: "http://192.168.x.x:8123"
ha_token: "Bearer eyJ..."
